### PR TITLE
types.CALL callee can be string or Expression

### DIFF
--- a/src/types/function.ts
+++ b/src/types/function.ts
@@ -21,11 +21,11 @@ import {
 } from "./primitives";
 
 export function CALL(
-  name: string,
+  name: string | Expression,
   args: Array<Expression>
 ): CallExpression {
   return callExpression(
-    ID(name),
+    typeof name === "string" ? ID(name) : name,
     args
   );
 }

--- a/tests/types/function.spec.ts
+++ b/tests/types/function.spec.ts
@@ -1,5 +1,6 @@
 import "jest";
 import dedent from "dedent";
+import * as BABEL_TYPES from "@babel/types";
 
 import { stringify, types } from "../../src";
 
@@ -20,6 +21,41 @@ describe("CALL", () => {
     expect(
       stringify`${value}`
     ).toBe(`fn("hi");`);
+  });
+
+  describe("callee", () => {
+    it("works with a string", () => {
+      const value = types.AS_STATEMENT(
+        types.CALL("fn", [])
+      );
+      expect(
+        stringify`${value}`
+      ).toBe("fn();");
+    });
+
+    it("works with an identifier", () => {
+      const value = types.AS_STATEMENT(
+        types.CALL(types.ID("id"), [])
+      );
+      expect(
+        stringify`${value}`
+      ).toBe("id();");
+    });
+
+    it("works with a member expression", () => {
+      const value = types.AS_STATEMENT(
+        types.CALL(
+          BABEL_TYPES.memberExpression(
+            types.ID("one"),
+            types.ID("two")
+          ),
+          []
+        )
+      );
+      expect(
+        stringify`${value}`
+      ).toBe("one.two();");
+    });
   });
 });
 


### PR DESCRIPTION
Previously, only strings were allowed, which meant member expressions could't be passed as the `callee` (`one.two()`).