### PR TITLE
Use props for types with multiple args

### DIFF
--- a/src/types/array.ts
+++ b/src/types/array.ts
@@ -2,4 +2,11 @@ import {
   arrayExpression
 } from "@babel/types";
 
-export const ARRAY = arrayExpression;
+import {
+  Expression,
+  SpreadElement
+} from "@babel/types";
+
+export function ARRAY(elements: Array<null | Expression | SpreadElement>) {
+  return arrayExpression(elements);
+};

--- a/src/types/comment.ts
+++ b/src/types/comment.ts
@@ -8,9 +8,36 @@ import {
 
 export type CommentLocation = "leading" | "trailing";
 
-// block comment
-export function COMMENT(node: Node, comment: string, where: CommentLocation) {
-  return addComment(node, where, ` ${comment} `, false);
+export interface CommentProps {
+  node: Node;
+  comment: string;
+  where: CommentLocation;
+  line?: boolean; // true for slash comment, false for block
+}
+
+export interface MultiLineCommentProps {
+  node: Node;
+  comments: Array<string>;
+  where: CommentLocation;
+}
+
+export function COMMENT(props: CommentProps) {
+  return addComment(
+    props.node,
+    props.where,
+    ` ${props.comment} `,
+    props.line
+  );
+}
+
+// slash comment
+export function SLASH_COMMENT(props: CommentProps) {
+  return addComment(
+    props.node,
+    props.where,
+    ` ${props.comment}`,
+    true
+  );
 }
 
 function fmtComments(comments: Array<string>): string {
@@ -18,11 +45,11 @@ function fmtComments(comments: Array<string>): string {
 }
 
 // multi-line block comment
-export function MULTI_LINE_COMMENT(node: Node, comments: Array<string>, where: CommentLocation) {
-  return addComment(node, where, fmtComments(comments));
-}
-
-// slash comment
-export function SLASH_COMMENT(node: Node, comment: string, where: CommentLocation) {
-  return addComment(node, where, ` ${comment}`, true);
+export function MULTI_LINE_COMMENT(props: MultiLineCommentProps) {
+  return addComment(
+    props.node,
+    props.where,
+    fmtComments(props.comments),
+    false
+  );
 }

--- a/src/types/expressions.ts
+++ b/src/types/expressions.ts
@@ -3,12 +3,33 @@ import {
   binaryExpression
 } from "@babel/types";
 
-import { Expression } from "@babel/types";
+import {
+  Expression,
+  SpreadElement,
+  JSXNamespacedName,
+  ArgumentPlaceholder
+} from "@babel/types";
+
+export interface NewProps {
+  callee: Expression;
+  arguments?: Array<Expression | SpreadElement | JSXNamespacedName | ArgumentPlaceholder>;
+}
+
+export interface BinaryProps {
+  operator: Operator;
+  left: Expression;
+  right: Expression;
+}
 
 export type Operator = "+" | "-" | "/" | "%" | "*" | "**" | "&" | "|" | ">>" | ">>>" | "<<" | "^" | "==" | "===" | "!=" | "!==" | "in" | "instanceof" | ">" | "<" | ">=" | "<=";
 
-export const NEW = newExpression;
+export function NEW(props: NewProps) {
+  return newExpression(
+    props.callee,
+    props.arguments || []
+  );
+}
 
-export function BINARY(left: Expression, operator: Operator, right: Expression) {
-  return binaryExpression(operator, left, right);
+export function BINARY(props: BinaryProps) {
+  return binaryExpression(props.operator, props.left, props.right);
 }

--- a/src/types/function.ts
+++ b/src/types/function.ts
@@ -12,43 +12,63 @@ import {
   Identifier,
   Pattern,
   RestElement,
-  TSParameterProperty,
-  Statement
+  Statement,
+  SpreadElement,
+  JSXNamespacedName,
+  ArgumentPlaceholder
 } from "@babel/types";
 
 import {
   ID
 } from "./primitives";
 
+export interface CallProps {
+  callee: Expression | string;
+  arguments?: Array<Expression | SpreadElement | JSXNamespacedName | ArgumentPlaceholder>;
+}
+
+export interface FunctionProps {
+  id: string | Identifier | null | undefined;
+  params?: Array<Identifier | Pattern | RestElement>;
+  body: Array<Statement>;
+  generator?: boolean;
+  async?: boolean;
+}
+
+export interface ArrowFunctionProps {
+  params?: Array<Identifier | Pattern | RestElement>;
+  body: Array<Statement> | Expression;
+  async?: boolean;
+}
+
 export function CALL(
-  name: string | Expression,
-  args: Array<Expression>
+  props: CallProps
 ): CallExpression {
   return callExpression(
-    typeof name === "string" ? ID(name) : name,
-    args
+    typeof props.callee === "string" ? ID(props.callee) : props.callee,
+    props.arguments || []
   );
 }
 
 export function FUNCTION(
-  name: string,
-  params: Array<Identifier | Pattern | RestElement | TSParameterProperty>,
-  body: Array<Statement>
+  props: FunctionProps
 ) {
   return functionDeclaration(
-    ID(name),
-    params,
-    blockStatement(body)
-  )
+    typeof props.id === "string" ? ID(props.id) : props.id,
+    props.params || [],
+    blockStatement(props.body),
+    props.generator,
+    props.async
+  );
 }
 
 export function ARROW_FUNCTION(
-  params: Array<Identifier | Pattern | RestElement | TSParameterProperty>,
-  body: Expression | Array<Statement>
+  props: ArrowFunctionProps
 ) {
   return arrowFunctionExpression(
-    params,
-    Array.isArray(body) ? blockStatement(body) : body
+    props.params || [],
+    Array.isArray(props.body) ? blockStatement(props.body) : props.body,
+    props.async
   );
 }
 

--- a/src/types/infer.ts
+++ b/src/types/infer.ts
@@ -30,16 +30,17 @@ export function INFER(value: Inferable): Expression {
       if (value === null) {
         return nullLiteral();
       } else if (Array.isArray(value)) {
-        return ARRAY(
-          value.map((i: Inferable) => INFER(i))
-        );
+        return ARRAY(value.map((i: Inferable) => INFER(i)));
       } else {
         return OBJECT(
           Object.keys(value)
             .map(
-              p => OBJECT_PROP(ID(p), INFER(value[p])
+              p => OBJECT_PROP({
+                key: ID(p),
+                value: INFER(value[p])
+              })
             )
-        ));
+        );
       }
     case "function":
       throw new Error(`INFER does not work with functions`);

--- a/src/types/module.ts
+++ b/src/types/module.ts
@@ -2,37 +2,43 @@ import {
   importDeclaration,
   importSpecifier,
   importDefaultSpecifier,
-  exportDefaultDeclaration,
-  exportNamedDeclaration
+  exportDefaultDeclaration
 } from "@babel/types";
 
 import { ID, STRING } from "./primitives";
 
 import {
   FunctionDeclaration,
-  TSDeclareFunction,
   ClassDeclaration,
   Expression
 } from "@babel/types";
 
-export function IMPORT_NAMED(names: Array<string>, src: string) {
+export interface ImportNamedProps {
+  names: Array<string>;
+  source: string;
+}
+
+export interface ImportDefaultProps {
+  name: string;
+  source: string;
+}
+
+export function IMPORT_NAMED(props: ImportNamedProps,) {
   return importDeclaration(
-    names.map(name => importSpecifier(ID(name), ID(name))),
-    STRING(src)
+    props.names.map(name => importSpecifier(ID(name), ID(name))),
+    STRING(props.source)
   );
 }
 
-export function IMPORT_DEFAULT(name: string, src: string) {
+export function IMPORT_DEFAULT(props: ImportDefaultProps) {
   return importDeclaration(
-    [
-      importDefaultSpecifier(ID(name))
-    ],
-    STRING(src)
+    [importDefaultSpecifier(ID(props.name))],
+    STRING(props.source)
   );
 }
 
 export function EXPORT_DEFAULT(
-  id: FunctionDeclaration | TSDeclareFunction | ClassDeclaration | Expression
+  declaration: FunctionDeclaration | ClassDeclaration | Expression
 ) {
-  return exportDefaultDeclaration(id);
+  return exportDefaultDeclaration(declaration);
 }

--- a/src/types/object.ts
+++ b/src/types/object.ts
@@ -16,26 +16,61 @@ import {
   PatternLike,
   Pattern,
   RestElement,
-  TSParameterProperty,
   Statement
 } from "@babel/types";
 
-export function OBJECT(properties: Array<ObjectProperty | ObjectMethod | SpreadElement>) {
+export interface ObjectPropertyProps {
+  key: any;
+  value: Expression | PatternLike;
+  computed?: boolean;
+  shorthand?: boolean;
+}
+
+export interface ObjectMethodProps {
+  kind?: "method" | "get" | "set" | undefined;
+  key: any;
+  params?: Array<Identifier | Pattern | RestElement>;
+  body?: Array<Statement>;
+  computed?: boolean;
+}
+
+export interface MemberProps {
+  object: Expression;
+  property: any;
+  computed?: boolean;
+  optional?: true | false | null;
+}
+
+export function OBJECT(properties: Array<ObjectMethod | ObjectProperty | SpreadElement>) {
   return objectExpression(properties);
 }
 
-export function OBJECT_PROP(key: Identifier, value: Expression | PatternLike) {
-  return objectProperty(key, value);
+export function OBJECT_PROP(props: ObjectPropertyProps) {
+  return objectProperty(
+    props.key,
+    props.value,
+    props.computed,
+    props.shorthand
+  );
 }
 
-export function OBJECT_METHOD(
-  kind: "method" | "get" | "set",
-  key: Identifier,
-  params: Array<Identifier | Pattern | RestElement | TSParameterProperty>,
-  body: Array<Statement>
-) {
-  return objectMethod(kind, key, params, blockStatement(body));
+export function OBJECT_METHOD(props: ObjectMethodProps) {
+  return objectMethod(
+    props.kind || "method",
+    props.key,
+    props.params || [],
+    blockStatement(props.body || []),
+    props.computed
+  );
 }
 
 export const SPREAD_OBJECT = spreadElement;
-export const MEMBER = memberExpression;
+
+export function MEMBER(props: MemberProps) {
+  return memberExpression(
+    props.object,
+    props.property,
+    props.computed,
+    props.optional
+  );
+}

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1,11 +1,34 @@
 export {
+  CommentLocation,
+  CommentProps,
+  MultiLineCommentProps
+} from "./comment";
+export {
+  NewProps,
+  BinaryProps,
+  Operator
+} from "./expressions";
+export {
+  CallProps,
+  FunctionProps,
+  ArrowFunctionProps
+} from "./function";
+export {
   Inferable,
   InferableArray,
   InferableObject
 } from "./infer";
 export {
-  CommentLocation
-} from "./comment";
+  ImportNamedProps,
+  ImportDefaultProps
+} from "./module";
 export {
-  Operator
-} from "./expressions";
+  ObjectProps,
+  ObjectPropertyProps,
+  ObjectMethodProps,
+  SpreadObjectProps,
+  MemberProps
+} from "./object";
+export {
+  VariableProps
+} from "./var";

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -23,10 +23,8 @@ export {
   ImportDefaultProps
 } from "./module";
 export {
-  ObjectProps,
   ObjectPropertyProps,
   ObjectMethodProps,
-  SpreadObjectProps,
   MemberProps
 } from "./object";
 export {

--- a/src/types/var.ts
+++ b/src/types/var.ts
@@ -9,6 +9,11 @@ import {
 
 import { ID } from "./primitives";
 
+export interface VariableProps {
+  name: string;
+  init: Expression
+}
+
 function genericVar(type: "const" | "let" | "var", name: string, init: Expression) {
   return variableDeclaration(
     type,
@@ -19,14 +24,14 @@ function genericVar(type: "const" | "let" | "var", name: string, init: Expressio
   );
 }
 
-export function CONST(name: string, init: Expression) {
-  return genericVar("const", name, init);
+export function CONST(props: VariableProps) {
+  return genericVar("const", props.name, props.init);
 }
 
-export function LET(name: string, init: Expression) {
-  return genericVar("let", name, init);
+export function LET(props: VariableProps) {
+  return genericVar("let", props.name, props.init);
 }
 
-export function VAR(name: string, init: Expression) {
-  return genericVar("var", name, init);
+export function VAR(props: VariableProps) {
+  return genericVar("var", props.name, props.init);
 }

--- a/tests/stringify.spec.ts
+++ b/tests/stringify.spec.ts
@@ -4,14 +4,20 @@ import { stringify, types } from "../src";
 
 describe("stringify", () => {
   it("returns string of nodes", () => {
-    const value = types.CONST("x", types.CALL("fn", []));
+    const value = types.CONST({
+      name: "x",
+      init: types.CALL({ callee: "fn" })
+    });
     expect(
       stringify`${value}`
     ).toBe("const x = fn();");
   });
 
   it("correctly interlaces with strings", () => {
-    const value = types.CONST("x", types.CALL("fn", []));
+    const value = types.CONST({
+      name: "x",
+      init: types.CALL({ callee: "fn" })
+    });
     expect(
       stringify`${value}
 // test`

--- a/tests/types/comment.spec.ts
+++ b/tests/types/comment.spec.ts
@@ -4,14 +4,52 @@ import dedent from "dedent";
 import { stringify, types } from "../../src";
 
 describe("COMMENT", () => {
-  describe("leading", () => {
-    it("attaches a comment before the node", () => {
-      const value = types.COMMENT(
-        types.AS_STATEMENT(
-          types.CALL("fn", [])
+  describe("where", () => {
+    it("attaches a comment before the node when where=leading", () => {
+      const value = types.COMMENT({
+        node: types.AS_STATEMENT(
+          types.CALL({ callee: "fn" })
         ),
-        "this is a comment",
-        "leading"
+        comment: "this is a comment",
+        where: "leading"
+      });
+
+      expect(
+        stringify`${value}`
+      ).toBe(dedent`
+        /* this is a comment */
+        fn();
+      `);
+    });
+
+    it("attaches a comment after the node when where=trailing", () => {
+      const value = types.COMMENT({
+        node: types.AS_STATEMENT(
+          types.CALL({ callee: "fn" })
+        ),
+        comment: "this is a comment",
+        where: "trailing"
+      }
+      );
+
+      expect(
+        stringify`${value}`
+      ).toBe(dedent`
+        fn();
+        /* this is a comment */
+      `);
+    });
+  });
+
+  describe("line", () => {
+    it("is a block comment when omitted", () => {
+      const value = types.COMMENT({
+        node: types.AS_STATEMENT(
+          types.CALL({ callee: "fn" })
+        ),
+        comment: "this is a comment",
+        where: "leading"
+      }
       );
 
       expect(
@@ -21,23 +59,40 @@ describe("COMMENT", () => {
         fn();
       `);
     });
-  });
 
-  describe("trailing", () => {
-    it("attaches a comment before the node", () => {
-      const value = types.COMMENT(
-        types.AS_STATEMENT(
-          types.CALL("fn", [])
+    it("is a block comment when false", () => {
+      const value = types.COMMENT({
+        node: types.AS_STATEMENT(
+          types.CALL({ callee: "fn" })
         ),
-        "this is a comment",
-        "trailing"
+        line: false,
+        comment: "this is a comment",
+        where: "leading"
+      }
       );
 
       expect(
         stringify`${value}`
       ).toBe(dedent`
-        fn();
         /* this is a comment */
+        fn();
+      `);
+    });
+
+    it("is a slash comment when true", () => {
+      const value = types.COMMENT({
+        node: types.AS_STATEMENT(
+          types.CALL({ callee: "fn" })
+        ),
+        line: true,
+        comment: "this is a comment",
+        where: "trailing"
+      });
+
+      expect(
+        stringify`${value}`
+      ).toBe(dedent`
+        fn(); // this is a comment
       `);
     });
   });
@@ -46,13 +101,13 @@ describe("COMMENT", () => {
 describe("MULTI_LINE_COMMENT", () => {
   describe("leading", () => {
     it("attaches a comment before the node", () => {
-      const value = types.MULTI_LINE_COMMENT(
-        types.AS_STATEMENT(
-          types.CALL("fn", [])
+      const value = types.MULTI_LINE_COMMENT({
+        node: types.AS_STATEMENT(
+          types.CALL({ callee: "fn" })
         ),
-        ["one", "two"],
-        "leading"
-      );
+        comments: ["one", "two"],
+        where: "leading"
+      });
 
       expect(
         stringify`${value}`
@@ -68,13 +123,13 @@ describe("MULTI_LINE_COMMENT", () => {
 
   describe("trailing", () => {
     it("attaches a comment after the node", () => {
-      const value = types.MULTI_LINE_COMMENT(
-        types.AS_STATEMENT(
-          types.CALL("fn", [])
+      const value = types.MULTI_LINE_COMMENT({
+        node: types.AS_STATEMENT(
+          types.CALL({ callee: "fn" })
         ),
-        ["one", "two"],
-        "trailing"
-      );
+        comments: ["one", "two"],
+        where: "trailing"
+      });
 
       expect(
         stringify`${value}`
@@ -89,41 +144,3 @@ describe("MULTI_LINE_COMMENT", () => {
   });
 });
 
-describe("SLASH_COMMENT", () => {
-  describe("leading", () => {
-    it("attaches a comment before the node", () => {
-      const value = types.SLASH_COMMENT(
-        types.AS_STATEMENT(
-          types.CALL("fn", [])
-        ),
-        "this is a comment",
-        "leading"
-      );
-
-      expect(
-        stringify`${value}`
-      ).toBe(dedent`
-        // this is a comment
-        fn();
-      `);
-    });
-  });
-
-  describe("trailing", () => {
-    it("attaches a comment before the node", () => {
-      const value = types.SLASH_COMMENT(
-        types.AS_STATEMENT(
-          types.CALL("fn", [])
-        ),
-        "this is a comment",
-        "trailing"
-      );
-
-      expect(
-        stringify`${value}`
-      ).toBe(dedent`
-        fn(); // this is a comment
-      `);
-    });
-  });
-});

--- a/tests/types/expressions.spec.ts
+++ b/tests/types/expressions.spec.ts
@@ -5,7 +5,9 @@ import { stringify, types } from "../../src";
 describe("NEW", () => {
   it("returns a new expression", () => {
     const value = types.AS_STATEMENT(
-      types.NEW(types.ID("Date"), [])
+      types.NEW({
+        callee: types.ID("Date")
+      })
     );
     expect(
       stringify`${value}`
@@ -16,7 +18,11 @@ describe("NEW", () => {
 describe("BINARY", () => {
   it("returns a binary expression", () => {
     const value = types.AS_STATEMENT(
-      types.BINARY(types.ID("value"), "<", types.NUMBER(7))
+      types.BINARY({
+        left: types.ID("value"),
+        operator: "<",
+        right: types.NUMBER(7)
+      })
     );
     expect(
       stringify`${value}`
@@ -25,11 +31,15 @@ describe("BINARY", () => {
 
   it("correctly chains binary expressions", () => {
     const value = types.AS_STATEMENT(
-      types.BINARY(
-        types.BINARY(types.NUMBER(6), "+", types.NUMBER(7)),
-        "*",
-        types.NUMBER(3)
-      )
+      types.BINARY({
+        left: types.BINARY({
+          left: types.NUMBER(6),
+          operator: "+",
+          right: types.NUMBER(7)
+        }),
+        operator: "*",
+        right: types.NUMBER(3)
+      })
     );
     expect(
       stringify`${value}`

--- a/tests/types/function.spec.ts
+++ b/tests/types/function.spec.ts
@@ -7,7 +7,9 @@ import { stringify, types } from "../../src";
 describe("CALL", () => {
   it("returns function being called", () => {
     const value = types.AS_STATEMENT(
-      types.CALL("fn", [])
+      types.CALL({
+        callee: "fn"
+      })
     );
     expect(
       stringify`${value}`
@@ -16,7 +18,10 @@ describe("CALL", () => {
 
   it("passes arguments to function call", () => {
     const value = types.AS_STATEMENT(
-      types.CALL("fn", [types.STRING("hi")])
+      types.CALL({
+        callee: "fn",
+        arguments: [types.STRING("hi")]
+      })
     );
     expect(
       stringify`${value}`
@@ -26,7 +31,9 @@ describe("CALL", () => {
   describe("callee", () => {
     it("works with a string", () => {
       const value = types.AS_STATEMENT(
-        types.CALL("fn", [])
+        types.CALL({
+          callee: "fn"
+        })
       );
       expect(
         stringify`${value}`
@@ -35,7 +42,9 @@ describe("CALL", () => {
 
     it("works with an identifier", () => {
       const value = types.AS_STATEMENT(
-        types.CALL(types.ID("id"), [])
+        types.CALL({
+          callee: types.ID("id")
+        })
       );
       expect(
         stringify`${value}`
@@ -44,13 +53,12 @@ describe("CALL", () => {
 
     it("works with a member expression", () => {
       const value = types.AS_STATEMENT(
-        types.CALL(
-          BABEL_TYPES.memberExpression(
-            types.ID("one"),
-            types.ID("two")
-          ),
-          []
-        )
+        types.CALL({
+          callee: types.MEMBER({
+            object:  types.ID("one"),
+            property:  types.ID("two")
+          })
+        })
       );
       expect(
         stringify`${value}`
@@ -61,10 +69,16 @@ describe("CALL", () => {
 
 describe("FUNCTION", () => {
   it("returns a function node", () => {
-    const value = types.FUNCTION("test", [], [
-      types.CONST("x", types.NUMBER(1)),
-      types.RETURN(types.ID("x"))
-    ]);
+    const value = types.FUNCTION({
+      id: "test",
+      body: [
+        types.CONST({
+          name: "x",
+          init: types.NUMBER(1)
+        }),
+        types.RETURN(types.ID("x"))
+      ]
+    });
     expect(
       stringify`${value}`
     ).toBe(dedent`
@@ -79,10 +93,15 @@ describe("FUNCTION", () => {
 describe("ARROW_FUNCTION", () => {
   it("works with an array of statements", () => {
     const value = types.AS_STATEMENT(
-      types.ARROW_FUNCTION([], [
-        types.CONST("x", types.NUMBER(1)),
-        types.RETURN(types.ID("x"))
-      ])
+      types.ARROW_FUNCTION({
+        body: [
+          types.CONST({
+            name: "x",
+            init: types.NUMBER(1)
+          }),
+          types.RETURN(types.ID("x"))
+        ]
+      })
     );
     expect(
       stringify`${value}`
@@ -96,7 +115,9 @@ describe("ARROW_FUNCTION", () => {
 
   it("works with a single expression", () => {
     const value = types.AS_STATEMENT(
-      types.ARROW_FUNCTION([], types.NUMBER(1))
+      types.ARROW_FUNCTION({
+        body: types.NUMBER(1)
+      })
     );
     expect(
       stringify`${value}`

--- a/tests/types/module.spec.ts
+++ b/tests/types/module.spec.ts
@@ -4,7 +4,10 @@ import { stringify, types } from "../../src";
 
 describe("IMPORT_DEFAULT", () => {
   it("returns default import string", () => {
-    const value = types.IMPORT_DEFAULT("thing", "somewhere")
+    const value = types.IMPORT_DEFAULT({
+      name: "thing",
+      source: "somewhere"
+    })
     expect(
       stringify`${value}`
     ).toBe(`import thing from "somewhere";`);
@@ -13,7 +16,10 @@ describe("IMPORT_DEFAULT", () => {
 
 describe("IMPORT_NAMED", () => {
   it("returns named import string", () => {
-    const value = types.IMPORT_NAMED(["thing"], "somewhere")
+    const value = types.IMPORT_NAMED({
+      names: ["thing"],
+      source: "somewhere"
+    })
     expect(
       stringify`${value}`
     ).toBe(`import { thing } from "somewhere";`);

--- a/tests/types/object.spec.ts
+++ b/tests/types/object.spec.ts
@@ -5,9 +5,14 @@ import { stringify, types } from "../../src";
 
 describe("OBJECT", () => {
   it("returns an objectExpression node", () => {
-    const value = types.AS_STATEMENT(types.OBJECT([
-      types.OBJECT_PROP(types.ID("x"), types.STRING("y"))
-    ]));
+    const value = types.AS_STATEMENT(
+      types.OBJECT([
+        types.OBJECT_PROP({
+          key: types.ID("x"),
+          value: types.STRING("y")
+        })
+      ])
+    );
     // AS_STATEMENT wraps in parentheses
     expect(
       stringify`${value}`
@@ -20,11 +25,21 @@ describe("OBJECT", () => {
   });
 
   it("works with multiple properties", () => {
-    const value = types.AS_STATEMENT(types.OBJECT([
-      types.OBJECT_PROP(types.ID("x"), types.STRING("X")),
-      types.OBJECT_PROP(types.ID("y"), types.STRING("Y")),
-      types.OBJECT_METHOD("method", types.ID("z"), [], [] )
-    ]));
+    const value = types.AS_STATEMENT(
+      types.OBJECT([
+        types.OBJECT_PROP({
+          key: types.ID("x"),
+          value: types.STRING("X")
+        }),
+        types.OBJECT_PROP({
+          key: types.ID("y"),
+          value: types.STRING("Y")
+        }),
+        types.OBJECT_METHOD({
+          key: types.ID("z")
+        })
+      ])
+    );
     // AS_STATEMENT wraps in parentheses, properties get
     // extra newlines (TODO: look into for custom printer)
     expect(
@@ -43,9 +58,14 @@ describe("OBJECT", () => {
 
 describe("OBJECT_PROP", () => {
   it("returns an objectProperty node with expected value", () => {
-    const value = types.AS_STATEMENT(types.OBJECT([
-      types.OBJECT_PROP(types.ID("x"), types.STRING("y"))
-    ]));
+    const value = types.AS_STATEMENT(
+      types.OBJECT([
+        types.OBJECT_PROP({
+          key: types.ID("x"),
+          value: types.STRING("y")
+        })
+      ])
+    );
     // AS_STATEMENT wraps in parentheses
     expect(
       stringify`${value}`
@@ -59,21 +79,22 @@ describe("OBJECT_PROP", () => {
 
 describe("OBJECT_METHOD", () => {
   it("returns an objectMethod node with expected value", () => {
-    const value = types.AS_STATEMENT(types.OBJECT([
-      types.OBJECT_METHOD(
-        "method",
-        types.ID("x"),
-        [types.ID("y")],
-        [
-          types.AS_STATEMENT(
-            types.CALL(
-              "log",
-              [types.ID("y")]
+    const value = types.AS_STATEMENT(
+      types.OBJECT([
+        types.OBJECT_METHOD({
+          key: types.ID("x"),
+          params: [types.ID("y")],
+          body: [
+            types.AS_STATEMENT(
+              types.CALL({
+                callee: "log",
+                arguments: [types.ID("y")]
+              })
             )
-          )
-        ]
-      )
-    ]));
+          ]
+        })
+      ])
+    );
     // AS_STATEMENT wraps in parentheses, objectMethod gets trailing
     // newline
     expect(
@@ -107,10 +128,12 @@ describe("SPREAD_OBJECT", () => {
 
 describe("MEMBER", () => {
   it("does not compute by default", () => {
-    const value = types.AS_STATEMENT(types.MEMBER(
-      types.ID("x"),
-      types.ID("y")
-    ));
+    const value = types.AS_STATEMENT(
+      types.MEMBER({
+        object: types.ID("x"),
+        property: types.ID("y")
+      })
+    );
     expect(
       stringify`${value}`
     ).toBe(dedent`
@@ -118,12 +141,14 @@ describe("MEMBER", () => {
     `);
   });
 
-  it("computes when compute=true", () => {
-    const value = types.AS_STATEMENT(types.MEMBER(
-      types.ID("x"),
-      types.STRING("y"),
-      true
-    ));
+  it("computes when computed=true", () => {
+    const value = types.AS_STATEMENT(
+      types.MEMBER({
+        object: types.ID("x"),
+        property: types.STRING("y"),
+        computed: true
+      })
+    );
     expect(
       stringify`${value}`
     ).toBe(dedent`

--- a/tests/types/statement.spec.ts
+++ b/tests/types/statement.spec.ts
@@ -4,7 +4,7 @@ import { stringify, types } from "../../src";
 describe("AS_STATEMENT", () => {
   it("returns expression wrapped as a statement", () => {
     const value = types.AS_STATEMENT(
-      types.CALL("fn", [])
+      types.CALL({ callee: "fn" })
     );
     expect(
       stringify`${value}`

--- a/tests/types/var.spec.ts
+++ b/tests/types/var.spec.ts
@@ -4,7 +4,10 @@ import { stringify, types } from "../../src";
 
 describe("CONST", () => {
   it("returns const variable declaration", () => {
-    const value = types.CONST("x", types.CALL("fn", []));
+    const value = types.CONST({
+      name: "x",
+      init: types.CALL({ callee: "fn" })
+    });
     expect(
       stringify`${value}`
     ).toBe("const x = fn();");
@@ -13,7 +16,10 @@ describe("CONST", () => {
 
 describe("LET", () => {
   it("returns let variable declaration", () => {
-    const value = types.LET("x", types.CALL("fn", []));
+    const value = types.LET({
+      name: "x",
+      init: types.CALL({ callee: "fn" })
+    });
     expect(
       stringify`${value}`
     ).toBe("let x = fn();");
@@ -22,7 +28,10 @@ describe("LET", () => {
 
 describe("VAR", () => {
   it("returns const variable declaration", () => {
-    const value = types.VAR("x", types.CALL("fn", []));
+    const value = types.VAR({
+      name: "x",
+      init: types.CALL({ callee: "fn" })
+    });
     expect(
       stringify`${value}`
     ).toBe("var x = fn();");

--- a/types/types/array.d.ts
+++ b/types/types/array.d.ts
@@ -1,2 +1,2 @@
-import { arrayExpression } from "@babel/types";
-export declare const ARRAY: typeof arrayExpression;
+import { Expression, SpreadElement } from "@babel/types";
+export declare function ARRAY(elements: Array<null | Expression | SpreadElement>): import("@babel/types").ArrayExpression;

--- a/types/types/comment.d.ts
+++ b/types/types/comment.d.ts
@@ -1,5 +1,16 @@
 import { Node } from "@babel/types";
 export declare type CommentLocation = "leading" | "trailing";
-export declare function COMMENT(node: Node, comment: string, where: CommentLocation): Node;
-export declare function MULTI_LINE_COMMENT(node: Node, comments: Array<string>, where: CommentLocation): Node;
-export declare function SLASH_COMMENT(node: Node, comment: string, where: CommentLocation): Node;
+export interface CommentProps {
+    node: Node;
+    comment: string;
+    where: CommentLocation;
+    line?: boolean;
+}
+export interface MultiLineCommentProps {
+    node: Node;
+    comments: Array<string>;
+    where: CommentLocation;
+}
+export declare function COMMENT(props: CommentProps): Node;
+export declare function SLASH_COMMENT(props: CommentProps): Node;
+export declare function MULTI_LINE_COMMENT(props: MultiLineCommentProps): Node;

--- a/types/types/expressions.d.ts
+++ b/types/types/expressions.d.ts
@@ -1,5 +1,13 @@
-import { newExpression } from "@babel/types";
-import { Expression } from "@babel/types";
+import { Expression, SpreadElement, JSXNamespacedName, ArgumentPlaceholder } from "@babel/types";
+export interface NewProps {
+    callee: Expression;
+    arguments?: Array<Expression | SpreadElement | JSXNamespacedName | ArgumentPlaceholder>;
+}
+export interface BinaryProps {
+    operator: Operator;
+    left: Expression;
+    right: Expression;
+}
 export declare type Operator = "+" | "-" | "/" | "%" | "*" | "**" | "&" | "|" | ">>" | ">>>" | "<<" | "^" | "==" | "===" | "!=" | "!==" | "in" | "instanceof" | ">" | "<" | ">=" | "<=";
-export declare const NEW: typeof newExpression;
-export declare function BINARY(left: Expression, operator: Operator, right: Expression): import("@babel/types").BinaryExpression;
+export declare function NEW(props: NewProps): import("@babel/types").NewExpression;
+export declare function BINARY(props: BinaryProps): import("@babel/types").BinaryExpression;

--- a/types/types/function.d.ts
+++ b/types/types/function.d.ts
@@ -1,6 +1,22 @@
 import { returnStatement } from "@babel/types";
-import { Expression, CallExpression, Identifier, Pattern, RestElement, TSParameterProperty, Statement } from "@babel/types";
-export declare function CALL(name: string | Expression, args: Array<Expression>): CallExpression;
-export declare function FUNCTION(name: string, params: Array<Identifier | Pattern | RestElement | TSParameterProperty>, body: Array<Statement>): import("@babel/types").FunctionDeclaration;
-export declare function ARROW_FUNCTION(params: Array<Identifier | Pattern | RestElement | TSParameterProperty>, body: Expression | Array<Statement>): import("@babel/types").ArrowFunctionExpression;
+import { Expression, CallExpression, Identifier, Pattern, RestElement, Statement, SpreadElement, JSXNamespacedName, ArgumentPlaceholder } from "@babel/types";
+export interface CallProps {
+    callee: Expression | string;
+    arguments?: Array<Expression | SpreadElement | JSXNamespacedName | ArgumentPlaceholder>;
+}
+export interface FunctionProps {
+    id: string | Identifier | null | undefined;
+    params?: Array<Identifier | Pattern | RestElement>;
+    body: Array<Statement>;
+    generator?: boolean;
+    async?: boolean;
+}
+export interface ArrowFunctionProps {
+    params?: Array<Identifier | Pattern | RestElement>;
+    body: Array<Statement> | Expression;
+    async?: boolean;
+}
+export declare function CALL(props: CallProps): CallExpression;
+export declare function FUNCTION(props: FunctionProps): import("@babel/types").FunctionDeclaration;
+export declare function ARROW_FUNCTION(props: ArrowFunctionProps): import("@babel/types").ArrowFunctionExpression;
 export declare const RETURN: typeof returnStatement;

--- a/types/types/module.d.ts
+++ b/types/types/module.d.ts
@@ -1,4 +1,12 @@
-import { FunctionDeclaration, TSDeclareFunction, ClassDeclaration, Expression } from "@babel/types";
-export declare function IMPORT_NAMED(names: Array<string>, src: string): import("@babel/types").ImportDeclaration;
-export declare function IMPORT_DEFAULT(name: string, src: string): import("@babel/types").ImportDeclaration;
-export declare function EXPORT_DEFAULT(id: FunctionDeclaration | TSDeclareFunction | ClassDeclaration | Expression): import("@babel/types").ExportDefaultDeclaration;
+import { FunctionDeclaration, ClassDeclaration, Expression } from "@babel/types";
+export interface ImportNamedProps {
+    names: Array<string>;
+    source: string;
+}
+export interface ImportDefaultProps {
+    name: string;
+    source: string;
+}
+export declare function IMPORT_NAMED(props: ImportNamedProps): import("@babel/types").ImportDeclaration;
+export declare function IMPORT_DEFAULT(props: ImportDefaultProps): import("@babel/types").ImportDeclaration;
+export declare function EXPORT_DEFAULT(declaration: FunctionDeclaration | ClassDeclaration | Expression): import("@babel/types").ExportDefaultDeclaration;

--- a/types/types/object.d.ts
+++ b/types/types/object.d.ts
@@ -1,7 +1,26 @@
-import { spreadElement, memberExpression } from "@babel/types";
-import { ObjectProperty, ObjectMethod, SpreadElement, Identifier, Expression, PatternLike, Pattern, RestElement, TSParameterProperty, Statement } from "@babel/types";
-export declare function OBJECT(properties: Array<ObjectProperty | ObjectMethod | SpreadElement>): import("@babel/types").ObjectExpression;
-export declare function OBJECT_PROP(key: Identifier, value: Expression | PatternLike): ObjectProperty;
-export declare function OBJECT_METHOD(kind: "method" | "get" | "set", key: Identifier, params: Array<Identifier | Pattern | RestElement | TSParameterProperty>, body: Array<Statement>): ObjectMethod;
+import { spreadElement } from "@babel/types";
+import { ObjectProperty, ObjectMethod, SpreadElement, Identifier, Expression, PatternLike, Pattern, RestElement, Statement } from "@babel/types";
+export interface ObjectPropertyProps {
+    key: any;
+    value: Expression | PatternLike;
+    computed?: boolean;
+    shorthand?: boolean;
+}
+export interface ObjectMethodProps {
+    kind?: "method" | "get" | "set" | undefined;
+    key: any;
+    params?: Array<Identifier | Pattern | RestElement>;
+    body?: Array<Statement>;
+    computed?: boolean;
+}
+export interface MemberProps {
+    object: Expression;
+    property: any;
+    computed?: boolean;
+    optional?: true | false | null;
+}
+export declare function OBJECT(properties: Array<ObjectMethod | ObjectProperty | SpreadElement>): import("@babel/types").ObjectExpression;
+export declare function OBJECT_PROP(props: ObjectPropertyProps): ObjectProperty;
+export declare function OBJECT_METHOD(props: ObjectMethodProps): ObjectMethod;
 export declare const SPREAD_OBJECT: typeof spreadElement;
-export declare const MEMBER: typeof memberExpression;
+export declare function MEMBER(props: MemberProps): import("@babel/types").MemberExpression;

--- a/types/types/types.d.ts
+++ b/types/types/types.d.ts
@@ -1,3 +1,7 @@
+export { CommentLocation, CommentProps, MultiLineCommentProps } from "./comment";
+export { NewProps, BinaryProps, Operator } from "./expressions";
+export { CallProps, FunctionProps, ArrowFunctionProps } from "./function";
 export { Inferable, InferableArray, InferableObject } from "./infer";
-export { CommentLocation } from "./comment";
-export { Operator } from "./expressions";
+export { ImportNamedProps, ImportDefaultProps } from "./module";
+export { ObjectProps, ObjectPropertyProps, ObjectMethodProps, SpreadObjectProps, MemberProps } from "./object";
+export { VariableProps } from "./var";

--- a/types/types/types.d.ts
+++ b/types/types/types.d.ts
@@ -3,5 +3,5 @@ export { NewProps, BinaryProps, Operator } from "./expressions";
 export { CallProps, FunctionProps, ArrowFunctionProps } from "./function";
 export { Inferable, InferableArray, InferableObject } from "./infer";
 export { ImportNamedProps, ImportDefaultProps } from "./module";
-export { ObjectProps, ObjectPropertyProps, ObjectMethodProps, SpreadObjectProps, MemberProps } from "./object";
+export { ObjectPropertyProps, ObjectMethodProps, MemberProps } from "./object";
 export { VariableProps } from "./var";

--- a/types/types/var.d.ts
+++ b/types/types/var.d.ts
@@ -1,4 +1,8 @@
 import { Expression } from "@babel/types";
-export declare function CONST(name: string, init: Expression): import("@babel/types").VariableDeclaration;
-export declare function LET(name: string, init: Expression): import("@babel/types").VariableDeclaration;
-export declare function VAR(name: string, init: Expression): import("@babel/types").VariableDeclaration;
+export interface VariableProps {
+    name: string;
+    init: Expression;
+}
+export declare function CONST(props: VariableProps): import("@babel/types").VariableDeclaration;
+export declare function LET(props: VariableProps): import("@babel/types").VariableDeclaration;
+export declare function VAR(props: VariableProps): import("@babel/types").VariableDeclaration;


### PR DESCRIPTION
For types that accept multiple arguments, use a props object. This can make things clearer (by naming the properties) and can also let us skip some props by using default values (e.g. call arguments).

For types that only accept one value, they take that value. This keeps them cleaner (at the cost of being a different API from the other types).