### PR TITLE
Support named exports

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -18,7 +18,10 @@ export {
 export {
   IMPORT_DEFAULT,
   IMPORT_NAMED,
-  EXPORT_DEFAULT
+  EXPORT_DEFAULT,
+  EXPORT_DECLARATION,
+  EXPORT_NAMED,
+  EXPORT_SPECIFIER
 } from "./module";
 export {
   NEW,

--- a/src/types/module.ts
+++ b/src/types/module.ts
@@ -2,15 +2,19 @@ import {
   importDeclaration,
   importSpecifier,
   importDefaultSpecifier,
-  exportDefaultDeclaration
+  exportDefaultDeclaration,
+  exportNamedDeclaration,
+  exportSpecifier
 } from "@babel/types";
 
 import { ID, STRING } from "./primitives";
 
 import {
+  Declaration,
   FunctionDeclaration,
   ClassDeclaration,
-  Expression
+  Expression,
+  ExportSpecifier
 } from "@babel/types";
 
 export interface ImportNamedProps {
@@ -21,6 +25,16 @@ export interface ImportNamedProps {
 export interface ImportDefaultProps {
   name: string;
   source: string;
+}
+
+export interface ExportNamedProps {
+  specifiers: Array<ExportSpecifier>;
+  source?: string | null
+}
+
+export interface ExportSpecifierProps {
+  local: string;
+  exported?: string
 }
 
 export function IMPORT_NAMED(props: ImportNamedProps,) {
@@ -41,4 +55,27 @@ export function EXPORT_DEFAULT(
   declaration: FunctionDeclaration | ClassDeclaration | Expression
 ) {
   return exportDefaultDeclaration(declaration);
+}
+
+export function EXPORT_DECLARATION(declaration: Declaration) {
+  return exportNamedDeclaration(
+    declaration,
+    [],
+    null
+  )
+}
+
+export function EXPORT_NAMED(props: ExportNamedProps) {
+  return exportNamedDeclaration(
+    undefined,
+    props.specifiers || [],
+    typeof props.source === "string" ? STRING(props.source) : props.source
+  );
+}
+
+export function EXPORT_SPECIFIER(props: ExportSpecifierProps) {
+  return exportSpecifier(
+    ID(props.local),
+    ID(props.exported || props.local)
+  )
 }

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -20,7 +20,9 @@ export {
 } from "./infer";
 export {
   ImportNamedProps,
-  ImportDefaultProps
+  ImportDefaultProps,
+  ExportNamedProps,
+  ExportSpecifierProps
 } from "./module";
 export {
   ObjectPropertyProps,

--- a/tests/types/module.spec.ts
+++ b/tests/types/module.spec.ts
@@ -35,3 +35,36 @@ describe("EXPORT_DEFAULT", () => {
     ).toBe(`export default thing;`);
   });
 });
+
+describe("EXPORT_DECLARATION", () => {
+  it("returns named declaration export string", () => {
+    const value = types.EXPORT_DECLARATION(
+      types.CONST({
+        name: "thing",
+        init: types.NUMBER(6)
+      })
+    );
+    expect(
+      stringify`${value}`
+    ).toBe(`export const thing = 6;`);
+  });
+});
+
+describe("EXPORT_NAMED & EXPORT_SPECIFIER", () => {
+  it("returns named export string", () => {
+    const value = types.EXPORT_NAMED({
+      specifiers: [
+        types.EXPORT_SPECIFIER({
+          local: "x"
+        }),
+        types.EXPORT_SPECIFIER({
+          local: "y",
+          exported: "z"
+        })
+      ]
+    });
+    expect(
+      stringify`${value}`
+    ).toBe(`export { x, y as z };`);
+  });
+});

--- a/types/types/index.d.ts
+++ b/types/types/index.d.ts
@@ -1,7 +1,7 @@
 export { CONST, LET, VAR } from "./var";
 export { ID, NUMBER, STRING, BOOLEAN } from "./primitives";
 export { CALL, FUNCTION, ARROW_FUNCTION, RETURN } from "./function";
-export { IMPORT_DEFAULT, IMPORT_NAMED, EXPORT_DEFAULT } from "./module";
+export { IMPORT_DEFAULT, IMPORT_NAMED, EXPORT_DEFAULT, EXPORT_DECLARATION, EXPORT_NAMED, EXPORT_SPECIFIER } from "./module";
 export { NEW, BINARY } from "./expressions";
 export { AS_STATEMENT } from "./statement";
 export { OBJECT, OBJECT_PROP, OBJECT_METHOD, SPREAD_OBJECT, MEMBER } from "./object";

--- a/types/types/module.d.ts
+++ b/types/types/module.d.ts
@@ -1,4 +1,4 @@
-import { FunctionDeclaration, ClassDeclaration, Expression } from "@babel/types";
+import { Declaration, FunctionDeclaration, ClassDeclaration, Expression, ExportSpecifier } from "@babel/types";
 export interface ImportNamedProps {
     names: Array<string>;
     source: string;
@@ -7,6 +7,17 @@ export interface ImportDefaultProps {
     name: string;
     source: string;
 }
+export interface ExportNamedProps {
+    specifiers: Array<ExportSpecifier>;
+    source?: string | null;
+}
+export interface ExportSpecifierProps {
+    local: string;
+    exported?: string;
+}
 export declare function IMPORT_NAMED(props: ImportNamedProps): import("@babel/types").ImportDeclaration;
 export declare function IMPORT_DEFAULT(props: ImportDefaultProps): import("@babel/types").ImportDeclaration;
 export declare function EXPORT_DEFAULT(declaration: FunctionDeclaration | ClassDeclaration | Expression): import("@babel/types").ExportDefaultDeclaration;
+export declare function EXPORT_DECLARATION(declaration: Declaration): import("@babel/types").ExportNamedDeclaration;
+export declare function EXPORT_NAMED(props: ExportNamedProps): import("@babel/types").ExportNamedDeclaration;
+export declare function EXPORT_SPECIFIER(props: ExportSpecifierProps): ExportSpecifier;

--- a/types/types/types.d.ts
+++ b/types/types/types.d.ts
@@ -2,6 +2,6 @@ export { CommentLocation, CommentProps, MultiLineCommentProps } from "./comment"
 export { NewProps, BinaryProps, Operator } from "./expressions";
 export { CallProps, FunctionProps, ArrowFunctionProps } from "./function";
 export { Inferable, InferableArray, InferableObject } from "./infer";
-export { ImportNamedProps, ImportDefaultProps } from "./module";
+export { ImportNamedProps, ImportDefaultProps, ExportNamedProps, ExportSpecifierProps } from "./module";
 export { ObjectPropertyProps, ObjectMethodProps, MemberProps } from "./object";
 export { VariableProps } from "./var";


### PR DESCRIPTION
Named exports are split between declarations and specifiers.

```js
EXPORT_DECLARATION(
  CONST({
    name: "x",
    init: NUMBER(1)
  })
);
EXPORT_SPECIFIER(
  FUNCTION({
    id: "test",
    body: [
      AS_STATEMENT(
        CALL({
          callee: MEMBER({ object: types.ID("console"), property: types.ID("log") }),
          arguments: [ types.INFER("test") ]
        })
      )
    ]
  })
);

export const x = 1;
export function test() {
  console.log("test");
}
```

```js
EXPORT_NAMED({
  specifiers: [
    EXPORT_SPECIFIER({ local "x" }),
    EXPORT_SPECIFIER({ local: "y", exported: "z" })
  ]
});

export { x, y as z };
```